### PR TITLE
Allow stopping from inside handle_info.

### DIFF
--- a/lib/smppex/protocol/mandatory_fields_specs.ex
+++ b/lib/smppex/protocol/mandatory_fields_specs.ex
@@ -184,7 +184,7 @@ defmodule SMPPEX.Protocol.MandatoryFieldsSpecs do
 
   def spec_for(:deliver_sm_resp) do
     [
-      {:message_id, {:c_octet_string, {:max, 1}}}
+      {:message_id, {:c_octet_string, {:max, 65}}}
     ]
   end
 


### PR DESCRIPTION
In our ESME, we spin up a few subprocesses and trap exits. If those subprocesses exit, we restart them when we catch their exits. But that means, the ESME will also ignore any Session termination signals. To get around that we added a catch-all that shuts down the esme, if it's not any of the known pids:

```elixir
    def handle_info({:EXIT, _pid, _reason}, st), do: {:stop, :session_stop}
```

But in order for this to work, SMPPEX needs to be able to stop from handle_info, just like GenServer. This patch adds that.