### PR TITLE
Fix mc_opts.

### DIFF
--- a/lib/smppex/mc.ex
+++ b/lib/smppex/mc.ex
@@ -289,9 +289,8 @@ defmodule SMPPEX.MC do
     acceptor_count = Keyword.get(opts, :acceptor_count, @default_acceptor_count)
     transport = Keyword.get(opts, :transport, @default_transport)
     transport_opts = Keyword.get(opts, :transport_opts, [{:port, 0}])
-    mc_opts = Keyword.get(opts, :mc_opts, [])
     handler = fn(ref, socket, transport, session) ->
-      case start_mc(mod_with_args, ref, socket, transport, session, mc_opts) do
+      case start_mc(mod_with_args, ref, socket, transport, session, opts) do
         {:ok,  mc} -> {:ok, SMPPEX.MC.SMPPHandler.new(mc)}
         {:error, _} = error -> error
       end


### PR DESCRIPTION
SMPPEX.MC.start was fetching the mc_opts and passing into start_mc, but then
start_mc would try to look up mc_opts (and gen_server_opts), thus looking at something
like: `[mc_opts: [mc_opts: []]]`.

https://github.com/savonarola/smppex/blob/491354a1d828aab2f693bfb9d3c541485af564d6/lib/smppex/mc.ex#L506-L514