### PR TITLE
Don't set duplicate optional fields

### DIFF
--- a/lib/smppex/pdu.ex
+++ b/lib/smppex/pdu.ex
@@ -238,7 +238,7 @@ defmodule SMPPEX.Pdu do
     end
   end
 
-  @spec set_optional_field(t, atom, any) :: t
+  @spec set_optional_field(t, integer | atom, any) :: t
 
   @doc """
   Sets Pdu optional field. New Pdu is returned.
@@ -252,8 +252,22 @@ defmodule SMPPEX.Pdu do
 
   """
 
-  def set_optional_field(pdu, name, value) do
-    %Pdu{pdu | optional: Map.put(pdu.optional, name, value)}
+  def set_optional_field(pdu, name, value) when is_atom(name) do
+    optional = Map.delete(pdu.optional, name)
+    optional = case TlvFormat.id_by_name(name) do
+      {:ok, id} -> Map.delete(optional, id)
+      :unknown -> optional
+    end
+    %Pdu{pdu | optional: Map.put(optional, name, value)}
+  end
+
+  def set_optional_field(pdu, id, value) when is_integer(id) do
+    optional = Map.delete(pdu.optional, id)
+    optional = case TlvFormat.name_by_id(id) do
+      {:ok, name} -> Map.delete(optional, name)
+      :unknown -> optional
+    end
+    %Pdu{pdu | optional: Map.put(optional, id, value)}
   end
 
   @spec field(t, integer | atom) :: any

--- a/test/pdu_test.exs
+++ b/test/pdu_test.exs
@@ -10,5 +10,13 @@ defmodule SMPPEX.PduTest do
     sequence_number: 123} = SMPPEX.Pdu.new({1, 0, 123}, %{system_id: "sid", password: "pass"}, %{})
   end
 
+  test "setting optional field doesn't allow duplicates" do
+    pdu = SMPPEX.Pdu.new({1, 1, 1}, %{}, %{1060 => "message1", message_payload: "message2"})
+    pdu_with_changed_payload = SMPPEX.Pdu.set_optional_field(pdu, :message_payload, "message3")
+    assert pdu_with_changed_payload.optional == %{message_payload: "message3"}
+    pdu_with_changed_payload = SMPPEX.Pdu.set_optional_field(pdu, 1060, "message3")
+    assert pdu_with_changed_payload.optional == %{1060 => "message3"}
+  end
+
 end
 


### PR DESCRIPTION
You are currently able to set duplicate optional fields when they are represented both with code and name.