### PR TITLE
Parser error handling

### DIFF
--- a/lib/smppex/esme/smpp_handler.ex
+++ b/lib/smppex/esme/smpp_handler.ex
@@ -21,8 +21,8 @@ defimpl SMPPEX.SMPPHandler, for: SMPPEX.ESME.SMPPHandler do
 
   require Logger
 
-  def handle_pdu(_session, {:unparsed_pdu, raw_pdu, error}) do
-    {:stop, {:parse_error, {:unparsed_pdu, raw_pdu, error}}}
+  def handle_pdu(session, {:unparsed_pdu, raw_pdu, error}) do
+    :ok = ESME.handle_parse_error(session.esme, {:unparsed_pdu, raw_pdu, error})
   end
 
   def handle_pdu(session, {:pdu, pdu}) do

--- a/lib/smppex/mc.ex
+++ b/lib/smppex/mc.ex
@@ -129,6 +129,13 @@ defmodule SMPPEX.MC do
   @callback handle_send_pdu_result(pdu :: Pdu.t, send_pdu_result :: SMPPEX.SMPPHandler.send_pdu_result, state) :: state
 
   @doc """
+  Invoked when the ESME fails to parse a pdu.
+
+  The returned value can either be :ok or {:stop, reason}.
+  """
+  @callback handle_parse_error(reason :: term, state) :: SMPPEX.SMPPHandler.handle_pdu_result
+
+  @doc """
   Invoked when the SMPP session is about to stop.
 
   `lost_pdus` contains sent PDUs which have not received resps (and will never
@@ -210,6 +217,9 @@ defmodule SMPPEX.MC do
       def handle_send_pdu_result(_pdu, _result, state), do: state
 
       @doc false
+      def handle_parse_error(reason, state), do: {:stop, reason, state}
+
+      @doc false
       def handle_stop(reason, lost_pdus, state) do
         Logger.info("mc_conn #{inspect self()} is stopping, reason: #{inspect reason}, lost_pdus: #{inspect lost_pdus}")
         {:normal, state}
@@ -235,6 +245,7 @@ defmodule SMPPEX.MC do
         handle_resp: 3,
         handle_resp_timeout: 2,
         handle_send_pdu_result: 3,
+        handle_parse_error: 2,
         handle_stop: 3,
         handle_call: 3,
         handle_cast: 2,
@@ -394,6 +405,13 @@ defmodule SMPPEX.MC do
     GenServer.call(mc, {:handle_send_pdu_result, pdu, send_pdu_result})
   end
 
+  @spec handle_parse_error(pid, reason :: term) :: :ok | {:error, term}
+
+  @doc false
+  def handle_parse_error(mc, reason) do
+    GenServer.call(mc, {:handle_parse_error, reason})
+  end
+
   # GenServer callbacks
 
   def init([{module, args}, mc_opts, _ref, socket, transport, session]) do
@@ -450,6 +468,10 @@ defmodule SMPPEX.MC do
 
   def handle_call({:handle_send_pdu_result, pdu, send_pdu_result}, _from, st) do
     do_handle_send_pdu_result(pdu, send_pdu_result, st)
+  end
+
+  def handle_call({:handle_parse_error, reason}, _from, st) do
+    do_handle_parse_error(reason, st)
   end
 
   def handle_call({:call, request}, from, st) do
@@ -578,6 +600,16 @@ defmodule SMPPEX.MC do
     new_module_state = st.module.handle_send_pdu_result(pdu, send_pdu_result, st.module_state)
     new_st = %MC{st | module_state: new_module_state}
     {:reply, :ok, new_st}
+  end
+
+  defp do_handle_parse_error(reason, st) do
+    case st.module.handle_parse_error(reason, st.module_state) do
+      {:ok, new_module_state} ->
+        new_st = %MC{st | module_state: new_module_state}
+        {:reply, :ok, new_st}
+      {:stop, reason, new_module_state} ->
+        {:stop, reason, :ok, %MC{st | module_state: new_module_state}}
+    end
   end
 
   defp do_handle_tick(time, st) do

--- a/lib/smppex/mc/smpp_handler.ex
+++ b/lib/smppex/mc/smpp_handler.ex
@@ -21,8 +21,8 @@ defimpl SMPPEX.SMPPHandler, for: SMPPEX.MC.SMPPHandler do
 
   require Logger
 
-  def handle_pdu(_session, {:unparsed_pdu, raw_pdu, error}) do
-    {:stop, {:parse_error, {:unparsed_pdu, raw_pdu, error}}}
+  def handle_pdu(session, {:unparsed_pdu, raw_pdu, error}) do
+    :ok = MC.handle_parse_error(session.mc_conn, {:unparsed_pdu, raw_pdu, error})
   end
 
   def handle_pdu(session, {:pdu, pdu}) do

--- a/test/esme_test.exs
+++ b/test/esme_test.exs
@@ -255,6 +255,16 @@ defmodule SMPPEX.ESMETest do
     ] = SupportESME.callbacks_received(ctx[:esme])
   end
 
+  test "handle_parse_error", ctx do
+    Server.send(ctx[:server], <<00, 00, 00, 0x10,   0x80, 00, 0x33, 0x02,   00, 00, 00, 00,   00, 00, 00, 0x01,   0xAA, 0xBB, 0xCC>>)
+    Timer.sleep(50)
+
+    assert [
+      {:init},
+      {:handle_parse_error, {:unparsed_pdu, _, "Unknown command_id"}}
+    ] = SupportESME.callbacks_received(ctx[:esme])
+  end
+
   test "enquire_link by timeout", ctx do
     pdu = SMPPEX.Pdu.Factory.bind_transmitter("system_id1", "pass1")
     ESME.send_pdu(ctx[:esme], pdu)

--- a/test/support/esme.ex
+++ b/test/support/esme.ex
@@ -42,6 +42,11 @@ defmodule Support.ESME do
     register_callback(st, {:handle_send_pdu_result, pdu, result})
   end
 
+  def handle_parse_error(reason, st) do
+    new_st = register_callback(st, {:handle_parse_error, reason})
+    {:ok, new_st}
+  end
+
   def handle_stop(reason, lost_pdus, st) do
     register_callback(st, {:handle_stop, reason, lost_pdus})
     {:normal, st}


### PR DESCRIPTION
Currently, upon receiving a parse error (such as a TLV length being wrong, etc.), the ESME/SMSC will just stop itself. Problem with that is, since we didn't send a response pdu back to the upstream, they will keep retrying to deliver the same faulty packet for days (and keep killing our server).

https://en.wikipedia.org/wiki/Short_Message_Peer-to-Peer#Extensibility.2C_compatibility_and_interoperability

> Since introduction of Tag-Length-Value (TLV) parameters in version 3.4, the SMPP may be regarded an extensible protocol. In order to achieve the highest possible degree of compatibility and interoperability any implementation should apply the Internet robustness principle: ″Be conservative in what you send, be liberal in what you accept″. It should use a minimal set of features which are necessary to accomplish a task. And if the goal is communication and not quibbling, each implementation should overcome minor nonconformities with standard:
> 
> [...]
> 
> - The borders of PDUs are always given by the PDUs' command_length field. Any message field must not exceed the end of PDU. **If a field is not properly finished, it should be treated as truncated at the end of PDU, and it should not affect further PDUs.**

 In most cases the error will be in the response body, so we'll have a RawPdu available at least, with the sequence num, etc. so that we can (n)ack. Instead of killing the connection, we should be able to make a decision and send a response packet (with an error_code, `ESME_RINVMSGLEN`, ...) to indicate to the upstream that we received the packet but considered it invalid.


I've added a handle_parse_error callback, but the docs for it are not correct yet. It allows you to make a decision on how to treat a parse error (the default implementation matching the old behaviour, stop the server). One can either return `{:ok, state}` or `{:stop, reason, state}` (just like in a GenServer).