### PR TITLE
deliver_sm_resp message_id: Loosen requirement

### DIFF
--- a/lib/smppex/protocol/mandatory_fields_specs.ex
+++ b/lib/smppex/protocol/mandatory_fields_specs.ex
@@ -184,7 +184,7 @@ defmodule SMPPEX.Protocol.MandatoryFieldsSpecs do
 
   def spec_for(:deliver_sm_resp) do
     [
-      {:message_id, {:c_octet_string, {:max, 1}}}
+      {:message_id, {:c_octet_string, {:max, 65}}}
     ]
   end
 


### PR DESCRIPTION
The spec for 3.4 requires message_id to be a max length of 1 (and should be set to NULL). However, a lot of software goes off spec and returns an actual ID. I was told this is so as to help support the ESME Delivery Acknowledgements which are not that well defined by spec.

The phrasing in 3.4 is also strict, saying "This field is unused and is set to NULL.", but in SMPP 5.0 they loosened the requirement and say the field has a max length of 65 (to match submit_sm_resp), and "should be set to NULL" (should, but might not be).

This change is present in a lot of client software that's proprietary and unfixable, so I think it's okay to go off-spec here and be a bit more lax regarding the field length; it will still work for anyone following the spec sending NULL, but it won't choke up on packets where an actual ID is returned either.