### PR TITLE
Fix extracting multipart info from single message

### DIFF
--- a/lib/smppex/pdu/multipart.ex
+++ b/lib/smppex/pdu/multipart.ex
@@ -51,6 +51,10 @@ defmodule SMPPEX.Pdu.Multipart do
       iex> SMPPEX.Pdu.Multipart.extract(data)
       {:ok, {3,2,1}, "message"}
 
+      iex> data = <<0, 104, 0, 105>> # "hi" in utf16
+      iex> SMPPEX.Pdu.Multipart.extract(data)
+      {:ok, :single, <<0, 104, 0, 105>>}
+
       iex> pdu = Pdu.new({1,0,1}, %{esm_class: 0b01000000, short_message: <<0x05, 0x00, 0x03, 0x03, 0x02, 0x01, "message">>})
       iex> SMPPEX.Pdu.Multipart.extract(pdu)
       {:ok, {3,2,1}, "message"}

--- a/lib/smppex/pdu/udh.ex
+++ b/lib/smppex/pdu/udh.ex
@@ -80,12 +80,17 @@ defmodule SMPPEX.Pdu.UDH do
   def extract(data) do
     case data do
       <<udh_length::integer-unsigned-size(8), rest::binary>> ->
-        case rest do
-          <<ies_data::binary-size(udh_length), message::binary>> ->
-            parse_ies(ies_data, message)
+        case udh_length do
+          0 -> {:ok, [], data}
 
           _ ->
-            {:error, @error_invalid_udh_length}
+            case rest do
+              <<ies_data::binary-size(udh_length), message::binary>> ->
+                parse_ies(ies_data, message)
+
+              _ ->
+                {:error, @error_invalid_udh_length}
+            end
         end
 
       _ ->


### PR DESCRIPTION
Calling SMPPEX.Pdu.Multipart.extract(single_message_data_in_utf16_be) returned incorrect result with first byte removed.