### PR TITLE
Fix ESME with SSL transport: v2

### DIFF
--- a/lib/smppex/esme.ex
+++ b/lib/smppex/esme.ex
@@ -89,7 +89,7 @@ defmodule SMPPEX.ESME do
 
     case transport.connect(convert_host(host), port, sock_opts, timeout) do
       {:ok, socket} ->
-        session_opts = {Session, [mod_with_args, esme_opts]}
+        session_opts = {Session, [mod_with_args, esme_opts], :esme}
 
         case TransportSession.start_link(socket, transport, session_opts) do
           {:ok, pid} ->

--- a/lib/smppex/mc.ex
+++ b/lib/smppex/mc.ex
@@ -88,7 +88,7 @@ defmodule SMPPEX.MC do
         transport,
         transport_opts,
         SMPPEX.TransportSession,
-        {SMPPEX.Session, [mod_with_args, mc_opts]}
+        {SMPPEX.Session, [mod_with_args, mc_opts], :smsc}
       )
 
     case start_result do

--- a/lib/smppex/transport_session.ex
+++ b/lib/smppex/transport_session.ex
@@ -111,6 +111,9 @@ defmodule SMPPEX.TransportSession do
 
     case module.init(socket, transport, module_opts) do
       {:ok, module_state} ->
+        :ok = ProcLib.init_ack({:ok, self()})
+        Ranch.accept_ack(ref)
+
         state = %TransportSession{
           ref: ref,
           socket: socket,
@@ -119,7 +122,10 @@ defmodule SMPPEX.TransportSession do
           module_state: module_state,
           buffer: <<>>
         }
-        GenServerErl.enter_loop(__MODULE__, [], state, 0)
+
+        wait_for_data(state)
+        GenServerErl.enter_loop(__MODULE__, [], state)
+
       {:stop, reason} ->
         :ok = ProcLib.init_ack({:error, reason})
     end
@@ -141,12 +147,6 @@ defmodule SMPPEX.TransportSession do
 
       {^error, _socket, reason} ->
         handle_socket_error(state, reason)
-
-      :timeout ->
-        :ok = ProcLib.init_ack({:ok, self()})
-        Ranch.accept_ack(state.ref)
-        wait_for_data(state)
-        {:noreply, state}
 
       _ ->
         do_handle_info(message, state)


### PR DESCRIPTION
Soooo, as it turns out, my last fix was wrong and ended up not working -- we'd connect, send a bind but never receive a response.

http://erlang.org/doc/apps/ssl/using_ssl.html

The real reason for the issues was that accept_ack should only be ran on the server side, and not the client-side. It's used for the server to do any sort of preparation necessary when opening a new connection.

It worked fine on ranch_tcp since accept_ack there was just an empty function:
https://github.com/ninenines/ranch/blob/b6f5b70ddbd7cb29cc26012e224fbbac67ca0432/src/ranch_tcp.erl#L104

But that's not the case with SSL, which starts the SSL handshake
(server -> client) and waits for a response:
https://github.com/ninenines/ranch/blob/b6f5b70ddbd7cb29cc26012e224fbbac67ca0432/src/ranch_ssl.erl#L131

Ranch.accept_ack catches a :shoot, then calls transport.accept_ack. I went for the simplest fix which is to still trigger :shoot (in order to block until the supervisor is ready), but to just catch it as no-op, instead of using accept_ack.

I'm sure there's a much cleaner solution to this, but we needed something working, you can probably clean it up further.