### PR TITLE
Refactor the TONNPIDefaults to fix some edge cases + 2x speed.

### DIFF
--- a/lib/smppex/pdu/ton_npi_defaults.ex
+++ b/lib/smppex/pdu/ton_npi_defaults.ex
@@ -3,36 +3,33 @@ defmodule SMPPEX.Pdu.TONNPIDefaults do
   Module for automatic TON/NPI detection
   """
 
-  @short_code_re ~r/\A\d{3,8}\z/
-  @long_code_lengths 10..15
-  @numeric_re ~r/\A\+?(?<digits>\d+)\z/
-
   def ton_npi(address) when is_binary(address) do
     address
     |> address_type()
     |> ton_npi_by_type()
   end
 
-  defp address_type(address) do
-    if address =~ @short_code_re do
-      :short_code
-    else
-      case Regex.named_captures(@numeric_re, address) do
-        nil ->
-          :alphanumeric
+  @num ~r/\A\+?[[:digit:]]+\z/
+  @alnum ~r/\A[[:alnum:]]{1,30}\z/
 
-        %{"digits" => digits} ->
-          if String.length(digits) in @long_code_lengths do
-            :long_code
-          else
-            :unknown
-          end
+  defp address_type(address) do
+    if Regex.match?(@num, address) do
+      case String.length(address) do
+        x when x in 3..8 -> :shortcode
+        x when x in 9..16 -> :longcode
+        _ -> :unknown
+      end
+    else
+      if Regex.match?(@alnum, address) do
+        :alphanumeric
+      else
+        :unknown
       end
     end
   end
 
-  defp ton_npi_by_type(:short_code), do: {3, 0}
-  defp ton_npi_by_type(:long_code), do: {1, 1}
+  defp ton_npi_by_type(:shortcode), do: {3, 0}
+  defp ton_npi_by_type(:longcode), do: {1, 1}
   defp ton_npi_by_type(:alphanumeric), do: {5, 0}
   defp ton_npi_by_type(:unknown), do: {0, 0}
 end

--- a/test/pdu/ton_npi_defaults_test.exs
+++ b/test/pdu/ton_npi_defaults_test.exs
@@ -5,7 +5,7 @@ defmodule SMPPEX.Pdu.TONNPIDefaultsTest do
 
   test "ton_npi" do
     assert {5, 0} == TONNPIDefaults.ton_npi("alphanumeric0")
-    assert {5, 0} == TONNPIDefaults.ton_npi("00+0")
+    assert {0, 0} == TONNPIDefaults.ton_npi("00+0") # invalid
     assert {1, 1} == TONNPIDefaults.ton_npi("71234567890")
     assert {1, 1} == TONNPIDefaults.ton_npi("+012345678901234")
     assert {3, 0} == TONNPIDefaults.ton_npi("12345")


### PR DESCRIPTION
Hi! So I saw that the TON defaults have been merged recently, and I decided to port over the module we've been using in production. It's a bit more correct and a bit faster.

- 9 digit number could technically be a valid local number
- `0+00` is invalid, alphanum can only contain a-Z0-9

I also think the type function could be exposed as an API on SMPPEX.Pdu or Did or somewhere, it's sometimes useful to be able to determine the number type.

Benchmarks:

```
Operating System: macOS"
CPU Information: Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
Number of Available Cores: 8
Available memory: 16 GB
Elixir 1.7.1
Erlang 21.0.4

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 5 s
memory time: 2 s
parallel: 1
inputs: none specified
Estimated total run time: 18 s

```
```
Benchmarking shortcode new...
Benchmarking shortcode old...

Name                    ips        average  deviation         median         99th %
shortcode new      582.39 K        1.72 μs   ±412.13%           2 μs           2 μs
shortcode old      444.67 K        2.25 μs  ±1113.05%           2 μs           3 μs

Comparison:
shortcode new      582.39 K
shortcode old      444.67 K - 1.31x slower

Memory usage statistics:

Name             Memory usage
shortcode new            72 B
shortcode old           224 B - 3.11x memory usage

```
```
Benchmarking longcode new...
Benchmarking longcode old...

Name                   ips        average  deviation         median         99th %
longcode new      534.19 K        1.87 μs  ±1491.37%           2 μs           3 μs
longcode old      304.09 K        3.29 μs   ±682.07%           3 μs           5 μs

Comparison:
longcode new      534.19 K
longcode old      304.09 K - 1.76x slower

Memory usage statistics:

Name            Memory usage
longcode new         0.91 KB
longcode old         1.21 KB - 1.34x memory usage

```
```
Benchmarking +longcode new...
Benchmarking +longcode old...

Name                    ips        average  deviation         median         99th %
+longcode new      513.56 K        1.95 μs  ±1511.88%           2 μs           3 μs
+longcode old      306.41 K        3.26 μs   ±737.59%           3 μs           5 μs

Comparison:
+longcode new      513.56 K
+longcode old      306.41 K - 1.68x slower

Memory usage statistics:

Name             Memory usage
+longcode new         0.98 KB
+longcode old         1.21 KB - 1.23x memory usage
```