### PR TITLE
Fix sequence numbers

### DIFF
--- a/lib/smppex/session.ex
+++ b/lib/smppex/session.ex
@@ -40,7 +40,7 @@ defmodule SMPPEX.Session do
     :pdus,
     :auto_pdu_handler,
     :response_limit,
-    :sequence_number,
+    :sequence_number, # increment before use
     :time,
     :timer_resolution,
     :tick_timer_ref


### PR DESCRIPTION
* There is a race condition where enquire_link and submit_sm_resp
  are interleaved, while using the same sequence number.
  As a consequence, the submit response is lost.
* This commit fixes the duplicate sequence number.
  Also, removes needless increment by 2, because enquire_link_resp
  uses other party's sequence.