### PR TITLE
fix converting oserl's short_message for non-latin encoding

### DIFF
--- a/lib/smppex/pdu/oserl.ex
+++ b/lib/smppex/pdu/oserl.ex
@@ -93,7 +93,7 @@ defmodule SMPPEX.Pdu.Oserl do
     end
   end
 
-  defp list_to_string({key, value}) when is_list(value), do: {key, List.to_string(value)}
+  defp list_to_string({key, value}) when is_list(value), do: {key, :erlang.list_to_binary(value)}
   defp list_to_string({key, value}), do: {key, value}
 
   defp string_to_list({key, value}) when is_binary(value),


### PR DESCRIPTION
Oserl doesn't decode short_message field. It's short_message is a list of bytes, not a codepoints