### PR TITLE
adds the ability to include a sequence ID for a deliver_sm_resp PDU

### DIFF
--- a/lib/smppex/pdu/factory.ex
+++ b/lib/smppex/pdu/factory.ex
@@ -282,8 +282,8 @@ defmodule SMPPEX.Pdu.Factory do
 
   @spec deliver_sm_resp(non_neg_integer) :: Pdu.t()
 
-  def deliver_sm_resp(command_status \\ 0) do
+  def deliver_sm_resp(command_status \\ 0, sequence_number \\ 0) do
     {:ok, command_id} = CommandNames.id_by_name(:deliver_sm_resp)
-    Pdu.new({command_id, command_status, 0})
+    Pdu.new({command_id, command_status, sequence_number})
   end
 end

--- a/test/pdu/factory_test.exs
+++ b/test/pdu/factory_test.exs
@@ -70,6 +70,10 @@ defmodule SMPPEX.Pdu.FactoryTest do
     assert %Pdu{} = Factory.deliver_sm_resp(0)
   end
 
+  test "deliver_sm_resp with sequence number" do
+    assert %Pdu{sequence_number: 10} = Factory.deliver_sm_resp(0, 10)
+  end
+
   test "delivery_report" do
     assert %Pdu{} = Factory.delivery_report("message_id", {"to", 0, 0}, {"from", 0, 0})
 


### PR DESCRIPTION
My SMSC requires that the sequence ID of the `deliver_sm` PDU is returned when acknowledging a received message.

This allows the ability to pass in the sequence ID for a `deliver_sm_resp` PDU while maintaining backwards compatibility.