### PR TITLE
fix no case clause matching

### DIFF
--- a/lib/smppex/session.ex
+++ b/lib/smppex/session.ex
@@ -430,6 +430,9 @@ defmodule SMPPEX.Session do
           | auto_pdu_handler: new_auto_pdu_handler
         })
 
+      {new_auto_pdu_handler, :skip} ->
+        {:ok, [], %Session{new_st | auto_pdu_handler: new_auto_pdu_handler}}
+
       {new_auto_pdu_handler, :skip, pdus} ->
         {:ok, pdus, %Session{new_st | auto_pdu_handler: new_auto_pdu_handler}}
     end

--- a/lib/smppex/session/auto_pdu_handler.ex
+++ b/lib/smppex/session/auto_pdu_handler.ex
@@ -50,7 +50,7 @@ defmodule SMPPEX.Session.AutoPduHandler do
     end
   end
 
-  @spec handle_pdu(t, Pdu.t()) :: {t, :proceed} | {t, :skip, [Pdu.t()]}
+  @spec handle_pdu(t, Pdu.t()) :: {t, :proceed} | {t, :skip, [Pdu.t()]} | {t, :skip}
 
   def handle_pdu(handler, pdu) do
     cond do


### PR DESCRIPTION
we have got an exeption
```
00:59:55.132 [error] GenServer #PID<0.7288.20> terminating
** (CaseClauseError) no case clause matching: {%SMPPEX.Session.AutoPduHandler{pdu_storage: %SMPPEX.PduStorage{id: :auto_pdus, by_sequence_number: #Reference<0.3583819919.2573074434.55621>, by_expire: #Reference<0.3583819919.2573074434.55622>, ttl: 60000, ttl_threshold: 100, timer: nil}, my_pdu_refs: MapSet.new([])}, :skip}
    (smppex 3.2.3) lib/smppex/session.ex:426: SMPPEX.Session.handle_pdu/2
    (smppex 3.2.3) lib/smppex/transport_session.ex:308: SMPPEX.TransportSession.handle_parse_result/3
    (stdlib 4.3) gen_server.erl:1123: :gen_server.try_dispatch/4
    (stdlib 4.3) gen_server.erl:1200: :gen_server.handle_msg/6
    (stdlib 4.3) proc_lib.erl:240: :proc_lib.init_p_do_apply/3
Last message: {:tcp, #Port<0.5207>, <<0, 0, 0, 16, 128, 0, 0, 21, 0, 0, 0, 0, 0, 0, 0, 2>>}
```
the problem is that AutoPduHandler.handle_pdu can return (in handle_resp)
{new_handler, :skip}
but there are no cases to it