### PR TITLE
ci: add Elixir 1.19 and OTP 28 coverage

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -10,6 +10,8 @@ jobs:
   test:
     name: Build and test
     runs-on: ubuntu-22.04
+    env:
+      MIX_ENV: test
 
     # https://github.com/elixir-lang/elixir/blob/main/lib/elixir/pages/references/compatibility-and-deprecations.md
     strategy:
@@ -75,18 +77,26 @@ jobs:
 
           # Elixir 1.18
 
-          - elixir: 1.18.0
-            otp_release: 27.1
+          - elixir: 1.18.4
+            otp_release: 27.3
+
+          # Elixir 1.19
+
+          - elixir: 1.19.5
+            otp_release: 27.3
+
+          - elixir: 1.19.5
+            otp_release: 28.1
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
     - name: Set up Elixir
       uses: erlef/setup-beam@v1
       with:
         elixir-version: ${{ matrix.elixir }}
         otp-version: ${{ matrix.otp_release }}
     - name: Restore dependencies cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: deps
         key: ${{ matrix.elixir }}-${{ matrix.otp_release }}-${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
@@ -106,14 +116,14 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       MIX_ENV: test
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
     - name: Set up Elixir
       uses: erlef/setup-beam@v1
       with:
-        elixir-version: '1.14.5'
-        otp-version: '25.3'
+        elixir-version: '1.19.5'
+        otp-version: '28.1'
     - name: Restore dependencies cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: deps
         key: coveralls-${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}

--- a/mix.exs
+++ b/mix.exs
@@ -34,10 +34,10 @@ defmodule Smppex.Mixfile do
   defp deps do
     [
       {:excoveralls, "~> 0.5", only: :test},
-      {:dialyxir, "~> 1.0", only: [:dev], runtime: false},
+      {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},
       {:earmark, "~> 1.4", only: :dev},
       {:ex_doc, "~> 0.23", only: :dev},
-      {:credo, "~> 1.5", only: [:dev, :test], runtime: false},
+      {:credo, "~> 1.5", only: [:dev], runtime: false},
       {:castore, "~> 1.0", only: [:dev, :test]},
       {:ranch, "~> 2.0"},
       {:ex2ms, "~> 1.0"},


### PR DESCRIPTION
## Summary
- add Elixir 1.19 / OTP 28 combinations to the CI matrix
- bump the existing Elixir 1.18 entry to the latest 1.18 patch release
- run the test job in MIX_ENV=test so test-only tooling is used consistently
- keep Credo out of test builds while making Dialyxir available in test for CI dialyzer runs
- refresh checkout/cache actions and align the code quality job with the latest stable toolchain

## Validation
- parsed `.github/workflows/elixir.yml` successfully
- ran `MIX_ENV=test mix format --check-formatted && MIX_ENV=test mix test && MIX_ENV=test mix dialyzer` in `elixir:1.19.5-otp-28` successfully
