### PR TITLE
set klotho as optional dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -46,7 +46,7 @@ defmodule Smppex.Mixfile do
       {:castore, "~> 1.0", only: [:dev, :test]},
       {:ranch, "~> 2.0"},
       {:ex2ms, "~> 1.0"},
-      {:klotho, "~> 0.1"}
+      {:klotho, "~> 0.1", optional: true}
     ]
   end
 


### PR DESCRIPTION
Hello, we have noticed, that when we include smppex to deps list of our application -> smmpex starts klotho application (as permanent), which forcibly sets :klotho_backend to Klotho.Mock (independently on MIX_ENV):

❯ mix release

Generated some_app app
Release some_app-2.16.13 already exists. Overwrite? [Yn] Y
* assembling some_app-2.16.13 on MIX_ENV=dev
* using config/runtime.exs to configure the release at runtime
* creating _build/dev/rel/some_app/releases/2.16.13/vm.args

Release created at _build/dev/rel/some_app

    # To start your system
    _build/dev/rel/some_app/bin/some_app start

Once the release is running:

    # To connect to it remotely
    _build/dev/rel/some_app/bin/some_app remote

    # To stop it gracefully (you may also send SIGINT/SIGTERM)
    _build/dev/rel/some_app/bin/some_app stop

To list all commands:

    _build/dev/rel/some_app/bin/some_app
    
❯ _build/dev/rel/some_app/bin/some_app start_iex
Erlang/OTP 27 [erts-15.2.7.6] [source] [64-bit] [smp:16:16] [ds:16:16:10] [async-threads:1] [jit:ns]
Interactive Elixir (1.18.4) - press Ctrl+C to exit (type h() ENTER for help)
iex(some_app@AcerNitro5)1> :persistent_term.get(:klotho_backend)
Klotho.Mock

As I understood, it could lead to using Klotho.Mock instead of Klotho.Real in all environments at runtime.
Setting klotho as an optional dependency in smppex allows not to require starting the klotho app for applications that have smppex in their dependencies.