### PR TITLE
move klotho to included_applications, to start on demand

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,10 @@ defmodule Smppex.Mixfile do
   end
 
   def application do
-    [extra_applications: [:logger]]
+    [
+      extra_applications: [:logger],
+      included_applications: [:klotho]
+    ]
   end
 
   defp deps do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,3 @@
 ExUnit.start()
+
+Application.ensure_all_started(:klotho)


### PR DESCRIPTION
Hello,

We have noticed that if include smppex to deps list of our application -> smmpex starts klotho application, which forcibly sets :klotho_backend to Klotho.Mock (independently of MIX_ENV):

❯ mix release

Generated some_app app
Release some_app-2.16.13 already exists. Overwrite? [Yn] Y

assembling some_app-2.16.13 on MIX_ENV=dev
using config/runtime.exs to configure the release at runtime
creating _build/dev/rel/some_app/releases/2.16.13/vm.args
Release created at _build/dev/rel/some_app

To start your system
_build/dev/rel/some_app/bin/some_app start
Once the release is running:

To connect to it remotely
_build/dev/rel/some_app/bin/some_app remote

To stop it gracefully (you may also send SIGINT/SIGTERM)
_build/dev/rel/some_app/bin/some_app stop
To list all commands:

_build/dev/rel/some_app/bin/some_app
❯ _build/dev/rel/some_app/bin/some_app start_iex
Erlang/OTP 27 [erts-15.2.7.6] [source] [64-bit] [smp:16:16] [ds:16:16:10] [async-threads:1] [jit:ns]
Interactive Elixir (1.18.4) - press Ctrl+C to exit (type h() ENTER for help)
iex(some_app@AcerNitro5)1> :persistent_term.get(:klotho_backend)
Klotho.Mock

It results in using Klotho.Mock instead of Klotho.Real in all MIX_ENVs at runtime.

Moving klotho to included_applications in smppex - allows to start klotho app (with Klotho.Mock :klotho_backend) on demand, when needed.